### PR TITLE
fix: scan annotated tags in release history

### DIFF
--- a/scripts/check_public_boundary.py
+++ b/scripts/check_public_boundary.py
@@ -881,7 +881,7 @@ def scan_history(root: Path) -> list[tuple[str, Path, int]]:
         object_type, raw_size = metadata
         if object_type == "tree":
             continue
-        if object_type != "blob":
+        if object_type not in {"blob", "tag"}:
             finding = ("git-history-object-type-unsupported", relative, 0)
             if finding not in seen:
                 seen.add(finding)
@@ -897,28 +897,38 @@ def scan_history(root: Path) -> list[tuple[str, Path, int]]:
                 seen.add(finding)
                 findings.append(finding)
             continue
+        history_path = (
+            Path("refs") / "tags" / relative
+            if object_type == "tag"
+            else relative
+        )
         if blob_size > MAX_FILE_BYTES:
-            finding = ("oversize-historical-blob", relative, 0)
+            rule = (
+                "oversize-historical-tag"
+                if object_type == "tag"
+                else "oversize-historical-blob"
+            )
+            finding = (rule, history_path, 0)
             if finding not in seen:
                 seen.add(finding)
                 findings.append(finding)
             continue
         try:
             blob = subprocess.run(
-                ["git", "cat-file", "blob", object_id],
+                ["git", "cat-file", object_type, object_id],
                 cwd=root,
                 check=False,
                 capture_output=True,
                 timeout=10,
             )
         except (OSError, subprocess.TimeoutExpired):
-            finding = ("git-history-read-unavailable", relative, 0)
+            finding = ("git-history-read-unavailable", history_path, 0)
             if finding not in seen:
                 seen.add(finding)
                 findings.append(finding)
             continue
         if blob.returncode != 0:
-            finding = ("git-history-read-unavailable", relative, 0)
+            finding = ("git-history-read-unavailable", history_path, 0)
             if finding not in seen:
                 seen.add(finding)
                 findings.append(finding)
@@ -926,11 +936,13 @@ def scan_history(root: Path) -> list[tuple[str, Path, int]]:
         try:
             text = blob.stdout.decode("utf-8")
         except UnicodeDecodeError:
-            blob_findings = list(scan_binary_metadata(blob.stdout, relative))
-            if relative.suffix.lower() not in REVIEWED_BINARY_ASSET_SUFFIXES:
+            blob_findings = list(scan_binary_metadata(blob.stdout, history_path))
+            if object_type == "tag":
+                blob_findings.append(("non-utf8-historical-tag", history_path, 0))
+            elif relative.suffix.lower() not in REVIEWED_BINARY_ASSET_SUFFIXES:
                 blob_findings.append(("non-utf8-historical-blob", relative, 0))
         else:
-            blob_findings = scan_text(text, relative)
+            blob_findings = scan_text(text, history_path)
         for finding in blob_findings:
             if finding not in seen:
                 seen.add(finding)

--- a/scripts/verify_public_boundary_fail_closed.py
+++ b/scripts/verify_public_boundary_fail_closed.py
@@ -28,6 +28,65 @@ def _joined(*parts: str) -> str:
     return "".join(parts)
 
 
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+
+
+def verify_annotated_tag_history(scanner_policy: dict[str, object]) -> bool:
+    with tempfile.TemporaryDirectory(prefix="awp-boundary-tag-") as raw:
+        fixture_root = Path(raw)
+        allowances = scanner_policy["SEMANTIC_ALLOWANCES"]
+        for relative in sorted({allowance.path for allowance in allowances}):
+            source = ROOT / relative
+            destination = fixture_root / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(source, destination)
+
+        _git(fixture_root, "init", "--quiet")
+        _git(fixture_root, "config", "user.name", "AWP Boundary Test")
+        _git(fixture_root, "config", "user.email", "boundary@example.invalid")
+        _git(fixture_root, "add", ".")
+        _git(fixture_root, "commit", "--quiet", "-m", "safe fixture")
+        _git(fixture_root, "tag", "-a", "safe-v1", "-m", "safe release")
+
+        safe_result = subprocess.run(
+            [sys.executable, str(SCANNER), str(fixture_root), "--history"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        if safe_result.returncode != 0:
+            print("FAILED: safe annotated tag was rejected", file=sys.stderr)
+            return False
+
+        secret = _joined("sk", "-", "P" * 24)
+        _git(fixture_root, "tag", "-a", "leak-v1", "-m", secret)
+        leak_result = subprocess.run(
+            [sys.executable, str(SCANNER), str(fixture_root), "--history"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        normalized = leak_result.stdout.replace("\\", "/")
+        marker = "openai-token-shape: refs/tags/leak-v1:"
+        if leak_result.returncode != 1 or marker not in normalized:
+            print("FAILED: annotated tag secret was not blocked", file=sys.stderr)
+            return False
+        if secret in leak_result.stdout:
+            print("FAILED: scanner printed annotated tag secret", file=sys.stderr)
+            return False
+    return True
+
+
 def main() -> int:
     scanner_policy = runpy.run_path(str(SCANNER))
     maximum = int(scanner_policy["MAX_FILE_BYTES"])
@@ -285,7 +344,13 @@ def main() -> int:
                 )
                 return 1
 
-    print(f"boundary fail-closed negative cases passed: {len(cases)}/{len(cases)}")
+    if not verify_annotated_tag_history(scanner_policy):
+        return 1
+
+    print(
+        f"boundary fail-closed negative cases passed: {len(cases)}/{len(cases)} "
+        "+ annotated tag history"
+    )
     return 0
 
 


### PR DESCRIPTION
## What changed
- accept annotated Git tag objects during reachable-history enumeration
- scan tag metadata and messages with the same public-boundary rules
- fail closed on oversized, unreadable, or non-UTF-8 tag objects
- add regression coverage proving a safe tag passes and a token in a tag is blocked without being printed

## Verification
- python scripts/verify_public_boundary_fail_closed.py
- python -m py_compile scripts/check_public_boundary.py scripts/verify_public_boundary_fail_closed.py
- python scripts/validate.py --component static --history